### PR TITLE
Fix build with GCC on 32bit x86

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ This snippet demonstrates how to retrieve the machine type of an executable on d
         // error handling
     }
     switch (file.fileHeader().machine()) {
-    case win32pe::FileHeader::i386:
+    case win32pe::FileHeader::arch_i386:
         std::cout << "i386 file\n";
         break;
-    case win32pe::FileHeader::amd64:
+    case win32pe::FileHeader::arch_amd64:
         std::cout << "amd64 file\n";
         break;
     default:

--- a/tests/test_load.cpp
+++ b/tests/test_load.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(test_load)
     BOOST_TEST(file.load(stringstream));
 
     // Test the file header
-    BOOST_TEST(file.fileHeader().machine() == win32pe::FileHeader::amd64);
+    BOOST_TEST(file.fileHeader().machine() == win32pe::FileHeader::arch_amd64);
     BOOST_TEST(file.fileHeader().timeDateStamp() == 1512189454);
     BOOST_TEST(file.fileHeader().characteristics() ==
         win32pe::FileHeader::RelocsStripped |

--- a/win32pe/include/win32pe/fileheader.h
+++ b/win32pe/include/win32pe/fileheader.h
@@ -42,8 +42,8 @@ class WIN32PE_EXPORT FileHeader
 public:
 
     enum {
-        i386  = 0x014c,
-        amd64 = 0x8664
+        arch_i386  = 0x014c,
+        arch_amd64 = 0x8664
     };
 
     enum {


### PR DESCRIPTION
GCC defines macro `i386` on x86[1]. This causes following compiler
errors:

	Scanning dependencies of target win32pe
	[ 11%] Building CXX object win32pe/CMakeFiles/win32pe.dir/src/file.cpp.o
	/root/win32pe/win32pe/include/win32pe/fileheader.h:45:9: error: expected identifier before numeric constant
	         i386  = 0x014c,
	         ^
	/root/win32pe/win32pe/include/win32pe/fileheader.h:45:9: error: expected ‘}’ before numeric constant
	/root/win32pe/win32pe/include/win32pe/fileheader.h:45:9: error: expected unqualified-id before numeric constant

[1] https://sourceforge.net/p/predef/wiki/Architectures/